### PR TITLE
Latest message: Alignment: Fix

### DIFF
--- a/src/pages/Chat.tsx
+++ b/src/pages/Chat.tsx
@@ -225,7 +225,7 @@ const Chat = () => {
                               {getContactName(u.userName, onlineFriends)}
                             </div>
                           </div>
-                          <div className="flex w-3/4 pl-2 ml-2 mb-1">
+                          <div className="flex w-3/4 mb-1">
                             <div className="flex flex-col w-full">
                               <div className={`h-1/2 mb-1 font-bold w-full`}>{u.userName}</div>
                               <div className={`h-1/2 w-full`}>
@@ -299,7 +299,7 @@ const Chat = () => {
                               )}
                             </div>
                           </div>
-                          <div className="flex w-3/4 items-center justify-start pl-2 ml-2 mb-1">
+                          <div className="flex w-3/4 items-center justify-start mb-1">
                             <div className="flex font-bold w-full">
                               {unContact.userName}
                             </div>

--- a/src/pages/Chat.tsx
+++ b/src/pages/Chat.tsx
@@ -300,7 +300,7 @@ const Chat = () => {
                               )}
                             </div>
                           </div>
-                          <div className="flex w-3/4 items-center justify-start">
+                          <div className="flex w-3/4 items-center justify-start pl-2 ml-2 mb-1">
                             <div className="flex font-bold w-full">
                               {unContact.userName}
                             </div>

--- a/src/pages/Chat.tsx
+++ b/src/pages/Chat.tsx
@@ -110,7 +110,6 @@ const Chat = () => {
     });
     setUsersList(data.users);
   };
-  console.log(usersList);
   useEffect(() => {
     fetchUsers();
     if (socket.current) {

--- a/src/pages/Chat.tsx
+++ b/src/pages/Chat.tsx
@@ -15,19 +15,34 @@ type MyEventMap = {
   getUsers: (users: string[]) => void;
 };
 
-interface User {
+interface ContactedUser {
   _id: string;
   userName: string;
-  conversation: string;
-  profileImage: {
-    url: string;
-  };
+  profileImage: ProfileImage;
+  conversation: Conversation;
+  language: string;
+}
+
+interface Conversation {
+  _id: string;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+interface ProfileImage {
+  public_id?: string;
+  url?: string;
+}
+
+interface UncontactedUser {
+  _id: string;
+  userName: string;
   language: string;
 }
 
 interface UsersList {
-  contactedUsers: User[];
-  uncontactedUsers: User[];
+  contactedUsers: ContactedUser[];
+  uncontactedUsers: UncontactedUser[];
 }
 
 const Chat = () => {
@@ -93,10 +108,9 @@ const Chat = () => {
         Authorization: `Bearer ${token}`,
       },
     });
-
     setUsersList(data.users);
   };
-
+  console.log(usersList);
   useEffect(() => {
     fetchUsers();
     if (socket.current) {
@@ -250,8 +264,8 @@ const Chat = () => {
                         }
                         onClick={() => handleSelectUnContact(unContact)}
                       >
-                        <div className="flex flex-row gap-4">
-                          <div className="h-full w-1/3 items-center justify-between">
+                        <div className="flex flex-row w-full">
+                          <div className="flex h-full w-1/4 items-center justify-center mx-2">
                             <div className="relative">
                               <div
                                 className="w-10 h-10 rounded-full shadow-sm flex items-center justify-center"
@@ -286,8 +300,8 @@ const Chat = () => {
                               )}
                             </div>
                           </div>
-                          <div className="flex w-2/3 items-center justify-center">
-                            <div className="text-center font-bold">
+                          <div className="flex w-3/4 items-center justify-start">
+                            <div className="flex font-bold w-full">
                               {unContact.userName}
                             </div>
                           </div>

--- a/src/pages/Chat.tsx
+++ b/src/pages/Chat.tsx
@@ -179,7 +179,7 @@ const Chat = () => {
                         }
                         onClick={() => handleSelectContact(u)}
                       >
-                        <div className="flex flex-row">
+                        <div className="flex flex-row w-full">
                           <div className="w-1/4 flex items-center justify-center mx-2">
                             <div className="relative">
                               <div
@@ -213,9 +213,9 @@ const Chat = () => {
                             </div>
                           </div>
                           <div className="flex w-3/4 pl-2 ml-2 mb-1">
-                            <div className="flex flex-col">
-                              <div className={`h-1/2 mb-1 font-bold`}>{u.userName}</div>
-                              <div className={`h-1/2`}>
+                            <div className="flex flex-col w-full">
+                              <div className={`h-1/2 mb-1 font-bold w-full`}>{u.userName}</div>
+                              <div className={`h-1/2 w-full`}>
                                 <FetchLatestMessages u={u} />
                               </div>
                             </div>

--- a/src/util/FetchLatestMessages.tsx
+++ b/src/util/FetchLatestMessages.tsx
@@ -4,21 +4,28 @@ import axios from "axios";
 import { toast } from "react-toastify";
 import { BASE_URL } from "../util/url.ts";
 
-interface FetchLatestMessagesProps {
+interface ContactedUser {
   _id: string;
   userName: string;
-  conversation: {
-    createdAt: string;
-    updatedAt: string;
-    _id: string;
-  };
-  profileImage: {
-    url: string;
-  };
+  profileImage: ProfileImage;
+  conversation: Conversation;
   language: string;
 }
 
-const FetchLatestMessages: React.FC<FetchLatestMessagesProps> = ({ u }) => {
+interface Conversation {
+  _id: string;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+interface ProfileImage {
+  public_id?: string;
+  url?: string;
+}
+
+const FetchLatestMessages: React.FC<{
+  u: ContactedUser;
+}> = ({ u }) => {
   const token: { token: string } | null = JSON.parse(
     localStorage.getItem("token") || "null"
   );
@@ -39,7 +46,7 @@ const FetchLatestMessages: React.FC<FetchLatestMessagesProps> = ({ u }) => {
           );
           const messages = data.conversation.messages;
           const lastMess = messages[messages.length - 1];
-          let truncateText;
+          let truncateText: string = "";
           if (lastMess && lastMess.message) {
             truncateText = lastMess.message.substring(0, 20);
             if (lastMess.message.length > 20) {


### PR DESCRIPTION
This PR solves #15.

- Friends Tab:
  - Latest message & username alignment is now fixed: Now every chat has the same dimensions no matter the message length.
  - <img width="222" alt="image" src="https://github.com/Talckatoo/talckatoo_client/assets/42615340/4f647d91-3290-4280-b7c6-82cd8ac85629">

- People Tab:
  - Usernames alignment is now fixed: now every chat has the same dimensions no matter the username length.
  - <img width="216" alt="image" src="https://github.com/Talckatoo/talckatoo_client/assets/42615340/57954940-80a8-41dd-ad70-0751773f53d7">

- Corrected UserList types on Chat.tsx.
- Corrected type of React.FC<{}> on FetchLatestMessages.tsx
